### PR TITLE
Bugfix/deprecation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .project
 .buildpath
 .settings

--- a/ActiveRecord.php
+++ b/ActiveRecord.php
@@ -40,7 +40,7 @@ function activerecord_autoload($class_name)
 		foreach ($namespaces as $directory)
 			$directories[] = $directory;
 
-		$root .= DIRECTORY_SEPARATOR . implode($directories, DIRECTORY_SEPARATOR);
+		$root .= DIRECTORY_SEPARATOR . implode(DIRECTORY_SEPARATOR, $directories);
 	}
 
 	$file = "$root/$class_name.php";

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 Version 1.2.1 - April 12, 2021
 
-- TODO
+- a814545 fixed deprecation issue with 'implode' function's arguments placing
 
 Version 1.0 - June 27, 2010
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
+Version 1.2.1 - April 12, 2021
+
+- TODO
+
 Version 1.0 - June 27, 2010
 
 - d2bed65 fixed an error with eager loading when no records exist
 - c225942 fixed set methods on DateTime objects to properly flag attributes as dirty
 - 46a1219 fixed a memory leak when using validations
-- c225942 fixed problem with some model functionality not working correctly after being deserialized 
+- c225942 fixed problem with some model functionality not working correctly after being deserialized
 - 3e26749 fixed validates_numericality_of to not ignore other options when only_integer is present and matches
 - 53ad5ec fixed ambiguous id error when finding by pk with a join option
 - 26e40f4 fixed conditions to accept DateTime values

--- a/test/helpers/AdapterTest.php
+++ b/test/helpers/AdapterTest.php
@@ -339,12 +339,12 @@ class AdapterTest extends DatabaseTest
 
 	public function test_query_column_info()
 	{
-		$this->assert_greater_than(0,count($this->conn->query_column_info("authors")));
+		$this->assert_greater_than(0,count($this->conn->query_column_info("authors")->fetch()));
 	}
 
 	public function test_query_table_info()
 	{
-		$this->assert_greater_than(0,count($this->conn->query_for_tables()));
+		$this->assert_greater_than(0,count($this->conn->query_for_tables()->fetch()));
 	}
 
 	public function test_query_table_info_must_return_one_field()


### PR DESCRIPTION
There is a deprecated `implode` function arguments placing happening in `ActiveRecord.php` file at line 43.
This PR fixes it. Also fixes two unit tests from failing.